### PR TITLE
Added a CI job that runs the test suite

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -114,3 +114,131 @@ jobs:
               throw [System.Exception]("ESLint found $($errors.Count) error(s). ❌")
           }
           Write-Host "No ESLint errors. Pass ✅ ($($warnings.Count) warning(s) ignored.)"
+
+
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      # lib-integration spawns the checked-in XmlFormatter CLI through `dotnet`, so the
+      # runtime named in lib/XmlFormatter.CommandLine.runtimeconfig.json has to be on PATH.
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        shell: pwsh
+        run: |
+          $reportPath = Join-Path $env:RUNNER_TEMP "vitest-report.json"
+          $PSNativeCommandUseErrorActionPreference = $false
+          pnpm exec vitest run --reporter=json --outputFile.json="$reportPath"
+          $vitestExit = $LASTEXITCODE
+
+          if (-not (Test-Path $reportPath)) {
+              throw [System.Exception]("Vitest exited $vitestExit without writing a report. ❌")
+          }
+
+          # 0 = all green, 1 = test or collection failures (reported below). Anything else is vitest itself failing.
+          if ($vitestExit -gt 1) {
+              throw [System.Exception]("Vitest exited $vitestExit. ❌")
+          }
+
+          $root = (Get-Location).Path
+          $report = Get-Content $reportPath -Raw | ConvertFrom-Json
+          $failures = foreach ($suite in $report.testResults) {
+              $relative = [System.IO.Path]::GetRelativePath($root, $suite.name).Replace("\", "/")
+              $fileName = [System.IO.Path]::GetFileName($suite.name)
+              $failed = @($suite.assertionResults | Where-Object { $_.status -eq "failed" })
+              foreach ($assertion in $failed) {
+                  # A failure message carries the assertion text and then a full stack. Keep the
+                  # text and the one frame inside the test file; the rest is @vitest/runner internals.
+                  $body = [System.Collections.Generic.List[string]]::new()
+                  $frame = ""
+                  foreach ($line in ($assertion.failureMessages -join "`n") -split "`r?`n") {
+                      if ($line -match "^\s*at ") {
+                          if ($frame -eq "" -and $line.Contains($fileName)) {
+                              $frame = $line.Trim()
+                          }
+                          continue
+                      }
+                      $body.Add($line)
+                  }
+                  if ($frame -ne "") {
+                      $body.Add($frame)
+                  }
+                  $lineNumber = 1
+                  $columnNumber = 1
+                  $position = [regex]::Match($frame, [regex]::Escape($fileName) + ":(\d+):(\d+)")
+                  if ($position.Success) {
+                      $lineNumber = $position.Groups[1].Value
+                      $columnNumber = $position.Groups[2].Value
+                  }
+                  [pscustomobject]@{
+                      File    = $relative
+                      Line    = $lineNumber
+                      Column  = $columnNumber
+                      Test    = $assertion.fullName
+                      Message = ($body -join "`n").Trim()
+                  }
+              }
+              # A suite that fails to collect - a bad import, a syntax error - reports no
+              # assertions at all, only a file-level message, and numFailedTests stays 0 for it.
+              if ($suite.status -eq "failed" -and $failed.Count -eq 0) {
+                  [pscustomobject]@{
+                      File    = $relative
+                      Line    = 1
+                      Column  = 1
+                      Test    = "(suite failed to run)"
+                      Message = if ([string]::IsNullOrWhiteSpace($suite.message)) { "Suite failed with no message." } else { $suite.message }
+                  }
+              }
+          }
+          $failures = @($failures)
+
+          # Inline annotations on the PR diff. GitHub needs %, CR and LF escaped.
+          foreach ($f in $failures) {
+              $text = $f.Message.Replace("%", "%25").Replace("`r", "%0D").Replace("`n", "%0A")
+              Write-Host "::error file=$($f.File),line=$($f.Line),col=$($f.Column),title=$($f.Test)::$text"
+          }
+
+          $summary = [System.Text.StringBuilder]::new()
+          [void]$summary.AppendLine("## Vitest")
+          [void]$summary.AppendLine("")
+          [void]$summary.AppendLine("$($report.numTotalTests) test(s) in $($report.numTotalTestSuites) suite(s): $($report.numPassedTests) passed, $($report.numFailedTests) failed, $($report.numPendingTests) skipped, $($report.numTodoTests) todo.")
+          if ($failures.Count -gt 0) {
+              [void]$summary.AppendLine("")
+              [void]$summary.AppendLine("| | File | Line | Test | Message |")
+              [void]$summary.AppendLine("| --- | --- | --- | --- | --- |")
+              foreach ($f in $failures) {
+                  # Escape the cell separator and flatten newlines; a test name or an
+                  # assertion diff carrying either would break the table across rows.
+                  $test = $f.Test.Replace("|", "\|")
+                  $cell = $f.Message.Replace("|", "\|").Replace("`r`n", "<br>").Replace("`r", "<br>").Replace("`n", "<br>")
+                  [void]$summary.AppendLine("| ❌ | $($f.File) | $($f.Line) | $test | $cell |")
+              }
+          }
+          $summary.ToString() | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+          if ($failures.Count -gt 0) {
+              throw [System.Exception]("Vitest found $($failures.Count) failure(s). ❌")
+          }
+          # A run can fail with no failure of either shape above, so the report's own verdict is the last gate.
+          if ($report.success -ne $true) {
+              throw [System.Exception]("Vitest reported the run as failed. ❌")
+          }
+          Write-Host "All $($report.numTotalTests) tests passed. Pass ✅"

--- a/src/test/lib-integration.test.ts
+++ b/src/test/lib-integration.test.ts
@@ -166,8 +166,11 @@ describe('DLL integration — earlier unicode fixes stay fixed (#208, #209, #211
         const result = await runDll('<Root sep="&#xD;&#xA;" b="x" />',
             FormattingActionKind.format,
             { allowWhiteSpaceUnicodesInAttributeValues: true });
-        expect(result).toContain('sep="&#xD;&#xA;"');
-        expect(result).not.toContain('\r');
+        // The guard is the attribute *value*, not the whole document. On Windows the engine
+        // separates the wrapped attributes with CRLF, so asserting the output holds no CR at
+        // all failed there while the entities were perfectly intact.
+        const separator = /sep="([^"]*)"/.exec(result)?.[1];
+        expect(separator).toBe('&#xD;&#xA;');
     }, 15000);
 
     it('#209 retains a lone space inside xsl:text when preserveNewLines is on', async () => {


### PR DESCRIPTION
pullrequest.yml checked engines and lint but never ran `vitest`, which is how the `xmlString` wire-contract break reached a rebase unnoticed. Adds a test job in the same report-and-annotate shape as lint: `vitest` JSON reporter, inline ::error annotations on the diff, a step-summary table, any failure fails the PR.

Installs .NET 10 via **actions/setup-dotnet@v6** — lib-integration spawns the checked-in `XmlFormatter` CLI through **dotnet**, so the runtime has to be on PATH. Gates on the parsed failure list plus the report's own success flag, since a suite that fails to collect reports no failed tests at all.