### PR TITLE
Deleted the inert .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,0 @@
-# Revisions listed here are formatting-only and are skipped by `git blame`.
-# Run once per clone to make it the default:
-#   git config blame.ignoreRevsFile .git-blame-ignore-revs
-
-# Reindented extension.ts to spaces and added @stylistic/indent
-03768b25384fd22daf0991d827ef8ad01a52312a


### PR DESCRIPTION
The file listed 03768b2, the pre-squash commit on tasks/eslint-argument-wrapping. That PR was squash-merged as 1d50b5b, which minted a new SHA, so the listed revision is reachable from no branch. It survives here only as a leftover object, which is why it looks fine locally; on a fresh clone anyone who has run the git config blame.ignoreRevsFile .git-blame-ignore-revs line the file itself recommends gets fatal: could not find object.

Swapping in 1d50b5b is not the fix — that commit is the squash of the reindent plus the webpack ESM migration and the eslint/package/tsconfig changes. Blame-ignore works per line, so it would skip the substantive lines too.

The premise of a blame-ignore file is that a formatting-only commit reaches main with a stable SHA, and the squash-merge workflow guarantees it does not: the SHA is minted at merge time and cannot be written into a file that is part of the same PR. Deleting is the honest option. If a reindent ever needs blame-ignoring, it can be done then as its own formatting-only PR with the SHA added in a follow-up commit after the merge.